### PR TITLE
Add support for async through transforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Duplex = require('stream').Duplex
+var Duplex = require('readable-stream').Duplex
 var inherits = require('inherits')
 var TA = require('typedarray')
 var U8 = typeof Uint8Array !== 'undefined' ? Uint8Array : TA.Uint8Array

--- a/test/through.js
+++ b/test/through.js
@@ -1,0 +1,22 @@
+var concat = require('../')
+var test = require('tape')
+
+function anAsyncFunction(blob, cb) {
+  cb(null, String(blob).toUpperCase())
+}
+
+test('duplex transform through concatenated stream', function (t) {
+  t.plan(1)
+
+  var through = concat({through:anAsyncFunction})
+  
+  through.pipe(concat(function (val) {
+    t.equal('ABCD', val)
+  }))
+
+  through.write('a')
+  through.write('b')
+  through.write('c')
+  through.write('d')
+  through.end()
+})


### PR DESCRIPTION
I tried a few ways of implementing `through`-like transforms which first buffer the input stream, for use with standard node-style async functions. In the end, I wound up re-implementing almost all of `concat-stream` in these modules.

It seems like either through functionality should be a part of `concat-stream`, as is implemented in this speculative PR, or else there should be a better primitive for writing `concat-stream` like modules.

This syntax seems clean to me, and there should be negligible overhead for creating Duplex rather than Writable streams. If you're into this approach, feel free to merge - otherwise I'll probably just publish this as another module and revisit it later to factor it better.

:cat2: 