### PR TITLE
upgrade to latest readable-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "inherits": "~2.0.1",
     "typedarray": "~0.0.5",
-    "readable-stream": "~1.1.9"
+    "readable-stream": "~2.0.0"
   },
   "devDependencies": {
     "tape": "~2.3.2"


### PR DESCRIPTION
we just released a new major version of readable-stream which upgrades it to streams3 (similar to latest node/io.js). this pr bumps the readable-stream dep in concat-stream to use that