### PR TITLE
Only require typedarray if necessary

### DIFF
--- a/test/buffer.js
+++ b/test/buffer.js
@@ -1,7 +1,11 @@
 var concat = require('../')
 var test = require('tape')
-var TA = require('typedarray')
-var U8 = typeof Uint8Array !== 'undefined' ? Uint8Array : TA.Uint8Array
+
+if (typeof Uint8Array === 'undefined') {
+  var U8 = require('typedarray').Uint8Array
+} else {
+  var U8 = Uint8Array
+}
 
 test('buffer stream', function (t) {
   t.plan(2)

--- a/test/string.js
+++ b/test/string.js
@@ -1,7 +1,11 @@
 var concat = require('../')
 var test = require('tape')
-var TA = require('typedarray')
-var U8 = typeof Uint8Array !== 'undefined' ? Uint8Array : TA.Uint8Array
+
+if (typeof Uint8Array === 'undefined') {
+  var U8 = require('typedarray').Uint8Array
+} else {
+  var U8 = Uint8Array
+}
 
 test('string -> buffer stream', function (t) {
   t.plan(2)

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -1,7 +1,11 @@
 var concat = require('../')
 var test = require('tape')
-var TA = require('typedarray')
-var U8 = typeof Uint8Array !== 'undefined' ? Uint8Array : TA.Uint8Array
+
+if (typeof Uint8Array === 'undefined') {
+  var U8 = require('typedarray').Uint8Array
+} else {
+  var U8 = Uint8Array
+}
 
 test('typed array stream', function (t) {
   t.plan(2)


### PR DESCRIPTION
Apply the same logic as a4b2ea249a795160806f588a3d305333c22be44a to the tests.