### PR TITLE
Update readable-stream and tape

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "inherits": "~2.0.1",
-    "typedarray": "~0.0.5",
-    "readable-stream": "~2.0.0"
+    "inherits": "^2.0.3",
+    "typedarray": "^0.0.6",
+    "readable-stream": "^2.2.2"
   },
   "devDependencies": {
-    "tape": "~2.3.2"
+    "tape": "^4.6.3"
   },
   "testling": {
     "files": "test/*.js",


### PR DESCRIPTION
Especially, `readable-stream` update helps better dependency deduplication while using npm v3.x.
