### PR TITLE
use `new` to instantiate all buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function stringConcat (parts) {
     } else if (Buffer.isBuffer(p)) {
       strings.push(p)
     } else {
-      strings.push(Buffer(p))
+      strings.push(new Buffer(p))
     }
   }
   if (Buffer.isBuffer(parts[0])) {
@@ -103,8 +103,8 @@ function bufferConcat (parts) {
       bufs.push(p)
     } else if (typeof p === 'string' || isArrayish(p)
     || (p && typeof p.subarray === 'function')) {
-      bufs.push(Buffer(p))
-    } else bufs.push(Buffer(String(p)))
+      bufs.push(new Buffer(p))
+    } else bufs.push(new Buffer(String(p)))
   }
   return Buffer.concat(bufs)
 }
@@ -121,7 +121,7 @@ function u8Concat (parts) {
   var len = 0
   for (var i = 0; i < parts.length; i++) {
     if (typeof parts[i] === 'string') {
-      parts[i] = Buffer(parts[i])
+      parts[i] = new Buffer(parts[i])
     }
     len += parts[i].length
   }

--- a/test/string.js
+++ b/test/string.js
@@ -42,7 +42,7 @@ test('string from mixed write encodings', function (t) {
     t.equal(out, 'nacho dogs')
   })
   strings.write('na')
-  strings.write(Buffer('cho'))
+  strings.write(new Buffer('cho'))
   strings.write([ 32, 100 ])
   var u8 = new U8(3)
   u8[0] = 111; u8[1] = 103; u8[2] = 115;

--- a/test/typedarray.js
+++ b/test/typedarray.js
@@ -14,7 +14,7 @@ test('typed array stream', function (t) {
 
   var arrays = concat({ encoding: 'Uint8Array' }, function(out) {
     t.equal(typeof out.subarray, 'function')
-    t.deepEqual(Buffer(out).toString('utf8'), 'abcde fg xyz')
+    t.deepEqual(new Buffer(out).toString('utf8'), 'abcde fg xyz')
   })
   arrays.write(a)
   arrays.write(b)
@@ -25,9 +25,9 @@ test('typed array from strings, buffers, and arrays', function (t) {
   t.plan(2)
   var arrays = concat({ encoding: 'Uint8Array' }, function(out) {
     t.equal(typeof out.subarray, 'function')
-    t.deepEqual(Buffer(out).toString('utf8'), 'abcde fg xyz')
+    t.deepEqual(new Buffer(out).toString('utf8'), 'abcde fg xyz')
   })
   arrays.write('abcde')
-  arrays.write(Buffer(' fg '))
+  arrays.write(new Buffer(' fg '))
   arrays.end([ 120, 121, 122 ])
 })


### PR DESCRIPTION
Using Buffer without `new` will soon stop working. It will throw
A deprecation warning in Node v7.