### PR TITLE
Removed unused variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,10 +65,6 @@ ConcatStream.prototype.getBody = function () {
   return this.body
 }
 
-var isArray = Array.isArray || function (arr) {
-  return Object.prototype.toString.call(arr) == '[object Array]'
-}
-
 function isArrayish (arr) {
   return /Array\]$/.test(Object.prototype.toString.call(arr))
 }


### PR DESCRIPTION
Was the intention to use `isArray` var on line 52, instead of Array.isArray?