### PR TITLE
Change format of field 'engines'

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "bugs": {
     "url": "http://github.com/maxogden/concat-stream/issues"
   },
-  "engines": [
-    "node >= 0.8"
-  ],
+  "engines": {
+    "node": ">= 0.8"
+  },
   "main": "index.js",
   "files": [
     "index.js"


### PR DESCRIPTION
Fixed the formatting so that package.json can pass the package.json validator at [](http://package-json-validator.com/) .  

The previous version was failing with the error: 
`{
  "valid": false,
  "errors": [
    "Type for field engines, was expected to be object, not object"
  ],
  "warnings": [
    "Missing recommended field: keywords",
    "Missing recommended field: contributors"
  ],
  "recommendations": [
    "Missing optional field: homepage"
  ]
}`